### PR TITLE
Add yanirseroussi.com

### DIFF
--- a/onionring-variables.js
+++ b/onionring-variables.js
@@ -21,7 +21,8 @@ var sites = [
     'https://simon.podhajsky.net/blog/',
     'https://www.heltweg.org/',
     'https://emilyriederer.com/',
-    'https://kylestratis.com'
+    'https://kylestratis.com',
+    'https://yanirseroussi.com/',
 ];
 
 //the name of the ring


### PR DESCRIPTION
Add https://yanirseroussi.com/ &ndash; I've been mostly writing about data (science) topics for about a decade, with varying frequencies. Can also use https://yanirseroussi.com/posts/ for a direct link to the posts.

I love the concept! Reminds me of the good old days...